### PR TITLE
build: update to new licence specification format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 authors = [{ name = "Joaquín León", email = "joaquinandresleon108@gmail.com" }]
 requires-python = ">=3.10"
-license.text = "MIT"
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 
 [project.urls]


### PR DESCRIPTION
The old format is deprecated and will be removed in the new year

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files